### PR TITLE
Added file type and size validation for profile picture in register

### DIFF
--- a/register.js
+++ b/register.js
@@ -2,23 +2,10 @@ document.addEventListener("DOMContentLoaded", function () {
     const form = document.getElementById("register-form");
 
     form.addEventListener("submit", function (e) {
-        const password = document.getElementById("password").value;
-        const confirmPassword = document.getElementById("confirm-password").value;
-
-        if (password !== confirmPassword) {
-            e.preventDefault();
-            alert("Passwords do not match!");
-            return false;
-        }
-
-        if (password.length < 6) {
-            e.preventDefault();
-            alert("Password must be at least 6 characters long.");
-            return false;
-        }
-
         const username = document.getElementById("username").value.trim();
         const email = document.getElementById("email").value.trim();
+        const password = document.getElementById("password").value;
+        const confirmPassword = document.getElementById("confirm-password").value;
         const profilePicture = document.getElementById("profile-picture").files[0];
 
         if (username.length < 3) {
@@ -33,9 +20,36 @@ document.addEventListener("DOMContentLoaded", function () {
             return false;
         }
 
+        if (password !== confirmPassword) {
+            e.preventDefault();
+            alert("Passwords do not match!");
+            return false;
+        }
+
+        if (password.length < 6) {
+            e.preventDefault();
+            alert("Password must be at least 6 characters long.");
+            return false;
+        }
+
         if (!profilePicture) {
             e.preventDefault();
             alert("Please upload a profile picture.");
+            return false;
+        }
+
+        const validTypes = ["image/jpeg", "image/png", "image/gif"];
+        const maxSize = 2 * 1024 * 1024;
+
+        if (!validTypes.includes(profilePicture.type)) {
+            e.preventDefault();
+            alert("Only JPG, PNG, or GIF images are allowed.");
+            return false;
+        }
+
+        if (profilePicture.size > maxSize) {
+            e.preventDefault();
+            alert("Profile picture must be less than 2MB.");
             return false;
         }
     });

--- a/register.php
+++ b/register.php
@@ -1,10 +1,9 @@
 <?php
 session_start();
-
 include ('config.php');
+
 // Form submission
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
-    // Sanitize user input
     $username = htmlspecialchars(trim($_POST['username']));
     $email = filter_var($_POST['email'], FILTER_SANITIZE_EMAIL);
     $password = $_POST['password'];
@@ -19,11 +18,26 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         // Hash the password
         $hashedPassword = password_hash($password, PASSWORD_DEFAULT);
 
-        // Handle profile picture upload
         $profilePicPath = '';
         if (isset($_FILES['profile-picture']) && $_FILES['profile-picture']['error'] === UPLOAD_ERR_OK) {
+            $allowedTypes = ['image/jpeg', 'image/png', 'image/gif'];
+            $maxSize = 2 * 1024 * 1024;
+
+            $fileType = mime_content_type($_FILES['profile-picture']['tmp_name']);
+            $fileSize = $_FILES['profile-picture']['size'];
+
+            if (!in_array($fileType, $allowedTypes)) {
+                echo "<script>alert('Only JPG, PNG, or GIF images are allowed.');</script>";
+                exit;
+            }
+
+            if ($fileSize > $maxSize) {
+                echo "<script>alert('Profile picture must be less than 2MB.');</script>";
+                exit;
+            }
+
             $targetDir = "uploads/";
-            if (!is_dir($targetDir)) mkdir($targetDir); // Create directory if not exists
+            if (!is_dir($targetDir)) mkdir($targetDir);
             $profilePicPath = $targetDir . basename($_FILES['profile-picture']['name']);
             move_uploaded_file($_FILES['profile-picture']['tmp_name'], $profilePicPath);
         }
@@ -43,7 +57,6 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 }
 ?>
 
-<!-- HTML Starts Below -->
 <!DOCTYPE html>
 <html lang="en">
 <head>


### PR DESCRIPTION
###  PR: Add File Validation to Register Form

**Description:**  
Implemented both client-side and server-side validation for the profile picture upload in `register.php`.

**Changes Made:**
-  Client-side (JS):
  - Checks for file type (`jpg`, `png`, `gif`)
  - File size must be under 2MB
-  Server-side (PHP):
  - Verifies MIME type using `mime_content_type`
  - Limits file size to 2MB
  - Rejects invalid file types with a JS alert

**Related Milestone Feedback:**
> “-5 no file validation in register.php” – This PR addresses and resolves that feedback.

**Checklist:**
- [x] Valid image types accepted (jpg, png, gif)
- [x] Image must be < 2MB
- [x] Alert shown for invalid input
- [x] Prevents form submission on failure
- [x] Fully tested locally

**Additional Notes:**  
Prepares the form for secure file handling. Profile pictures are stored in `/uploads/`. This closes out the missing validation from Milestone 2.
